### PR TITLE
PR - Center search title text in smaller window

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -121,6 +121,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  text-align: center;
   gap: 1rem;
 }
 .search h2 {


### PR DESCRIPTION
This PR resolves issue #30
Now the search title is centered in the smaller window as well.
![image](https://user-images.githubusercontent.com/30120066/194349168-bcd66b2d-f085-4d0c-b277-c87a08b35a6d.png)
