### PR TITLE
make weather data come up on page load for user location

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -98,6 +98,10 @@ function App() {
     getWeather([latitude, longitude]);
   };
 
+    // load current location weather info on load
+  window.addEventListener("load", function() {
+    navigator.geolocation.getCurrentPosition(myIP)
+  })
   return (
     <div className="container">
       <div


### PR DESCRIPTION
Fixes #42 
Weather information for the user's current location is fetched immediately the site loads when granted location access.