### PR TITLE
updated the CSS to make search bar text visible

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -166,6 +166,10 @@ body {
   width: 100%;
   padding: 0% 28%;
 }
+::placeholder {
+  color: var(--textColor);
+  opacity: 0.9; 
+}
 .search-bar > input {
   background-color: var(--cardColor);
   width: 100%;


### PR DESCRIPTION
I have attached the Screenshot of search in both dark and light mode. now the text is visible nicely.

![1 11](https://user-images.githubusercontent.com/79858905/195253646-8537f8b0-1d6e-4ee4-bf0f-63afd3f94874.png)
![1 13](https://user-images.githubusercontent.com/79858905/195253654-b63893ec-d572-4b02-b2e5-ba52f3fd2530.png)
